### PR TITLE
Fix Track 1 deployment script and tests

### DIFF
--- a/track1-basic/README.md
+++ b/track1-basic/README.md
@@ -15,7 +15,7 @@ Snekmate provides battle-tested, gas-optimized implementations of common smart c
 First, install the snekmate dependency:
 
 ```bash
-cd /home/charles/vyper-workshop
+cd /path/to/track1-basic
 mox install
 ```
 
@@ -39,7 +39,7 @@ anvil
 Then deploy your token:
 
 ```bash
-mox run track1-basic/script/deploy_token.py --network anvil
+mox run deploy_token --network anvil --private-key 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
 ```
 
 ### 4. Interact with Your Token
@@ -86,7 +86,7 @@ print(f"Your balance: {balance / 10**18} tokens")
 Test your token implementation:
 
 ```bash
-mox test track1-basic/tests/test_token.py -v
+mox test tests/test_token.py -v
 ```
 
 ## Key Learning Points
@@ -98,8 +98,8 @@ mox test track1-basic/tests/test_token.py -v
 
 ## Exercises
 
-1. **Add a Minting Function**: Modify the token to allow the owner to mint new tokens
-2. **Add Burn Functionality**: Allow token holders to burn their tokens
+1. **Understand Module Exports**: The ERC20 module already includes mint and burn functions. Explore how they work
+2. **Access Control**: Add custom admin functions that don't conflict with the ERC20 exports
 3. **Create a Faucet**: Create a separate contract that distributes tokens to users
 
 ## Next Steps

--- a/track1-basic/moccasin.toml
+++ b/track1-basic/moccasin.toml
@@ -1,9 +1,7 @@
 [project]
 src = "src"
 out = "out"
-
-[dependencies]
-snekmate = "^0.1.0"
+dependencies = ["snekmate"]
 
 [networks.anvil]
 url = "http://127.0.0.1:8545"

--- a/track1-basic/script/deploy_token.py
+++ b/track1-basic/script/deploy_token.py
@@ -3,8 +3,7 @@
 Deploy MyToken to the specified network
 """
 
-from boa.contracts.abi.abi_contract import ABIContractFactory
-from moccasin.boa_tools import VyperContract
+from src import MyToken
 import os
 import json
 
@@ -14,7 +13,7 @@ def deploy():
     print("🚀 Deploying MyToken...")
     
     # Deploy the contract
-    token = VyperContract("track1-basic/src/MyToken.vy")
+    token = MyToken.deploy()
     
     print(f"✅ MyToken deployed at: {token.address}")
     print(f"   Name: {token.name()}")
@@ -32,13 +31,13 @@ def deploy():
     }
     
     # Create deployments directory if it doesn't exist
-    os.makedirs("track1-basic/deployments", exist_ok=True)
+    os.makedirs("deployments", exist_ok=True)
     
     # Save deployment info
-    with open("track1-basic/deployments/MyToken.json", "w") as f:
+    with open("deployments/MyToken.json", "w") as f:
         json.dump(deployment_info, f, indent=2)
     
-    print(f"\n💾 Deployment info saved to track1-basic/deployments/MyToken.json")
+    print(f"\n💾 Deployment info saved to deployments/MyToken.json")
     
     return token
 

--- a/track1-basic/src/MyToken.vy
+++ b/track1-basic/src/MyToken.vy
@@ -9,8 +9,8 @@ from snekmate.tokens import erc20
 from snekmate.auth import ownable
 
 # We initialize the modules we're using
-initializes: erc20
 initializes: ownable
+initializes: erc20[ownable := ownable]
 
 # Re-export the ERC20 interface functions
 exports: erc20.__interface__
@@ -35,21 +35,3 @@ def __init__():
     
     # Mint initial supply to the deployer
     erc20._mint(msg.sender, INITIAL_SUPPLY)
-
-@external
-def mint(to: address, amount: uint256):
-    """
-    @notice Mint new tokens (owner only)
-    @param to Address to mint tokens to
-    @param amount Amount of tokens to mint
-    """
-    ownable._check_owner()
-    erc20._mint(to, amount)
-
-@external
-def burn(amount: uint256):
-    """
-    @notice Burn tokens from caller's balance
-    @param amount Amount of tokens to burn
-    """
-    erc20._burn(msg.sender, amount)

--- a/track1-basic/src/MyToken.vy
+++ b/track1-basic/src/MyToken.vy
@@ -19,13 +19,13 @@ initializes: ownable
 initializes: erc20[ownable := ownable]
 
 # Re-export the ERC20 interface functions
-exports: erc20.IERC20
+exports: erc20.__interface__
 
 # Token configuration
-name: public(constant(String[25])) = "Workshop Token"
-symbol: public(constant(String[5])) = "WSHOP"
-decimals: public(constant(uint8)) = 18
-_INITIAL_SUPPLY: constant(uint256) = 1_000_000 * 10**18  # 1 million tokens
+NAME: constant(String[25]) = "Workshop Token"
+SYMBOL: constant(String[5]) = "WSHOP"
+DECIMALS: constant(uint8) = 18
+INITIAL_SUPPLY: constant(uint256) = 1_000_000 * 10**18  # 1 million tokens
 
 
 @deploy
@@ -38,7 +38,7 @@ def __init__():
     ownable.__init__()
 
     # Initialize the ERC20 module with our token details
-    erc20.__init__(name, symbol, decimals, name, "1.0.0")
+    erc20.__init__(NAME, SYMBOL, DECIMALS, NAME, "1.0.0")
 
     # Mint initial supply to the deployer
-    erc20._mint(msg.sender, _INITIAL_SUPPLY)
+    erc20._mint(msg.sender, INITIAL_SUPPLY)

--- a/track1-basic/tests/test_token.py
+++ b/track1-basic/tests/test_token.py
@@ -3,14 +3,14 @@ Tests for MyToken contract
 """
 
 import pytest
-from moccasin.boa_tools import VyperContract
+from src import MyToken
 import boa
 
 
 def test_token_deployment(owner, alice):
     """Test basic token deployment"""
     # Deploy token
-    token = VyperContract("track1-basic/src/MyToken.vy")
+    token = MyToken.deploy()
     
     # Check token metadata
     assert token.name() == "Workshop Token"
@@ -26,7 +26,7 @@ def test_token_deployment(owner, alice):
 
 def test_transfer(owner, alice, bob):
     """Test token transfers"""
-    token = VyperContract("track1-basic/src/MyToken.vy")
+    token = MyToken.deploy()
     
     # Transfer tokens from owner to alice
     transfer_amount = 1000 * 10**18
@@ -51,7 +51,7 @@ def test_transfer(owner, alice, bob):
 
 def test_approve_and_transfer_from(owner, alice, bob):
     """Test approval and transferFrom mechanism"""
-    token = VyperContract("track1-basic/src/MyToken.vy")
+    token = MyToken.deploy()
     
     # Owner approves alice to spend tokens
     approval_amount = 500 * 10**18
@@ -76,7 +76,7 @@ def test_approve_and_transfer_from(owner, alice, bob):
 
 def test_mint_as_owner(owner, alice):
     """Test minting new tokens (owner only)"""
-    token = VyperContract("track1-basic/src/MyToken.vy")
+    token = MyToken.deploy()
     
     # Get initial supply
     initial_supply = token.totalSupply()
@@ -92,16 +92,16 @@ def test_mint_as_owner(owner, alice):
 
 def test_mint_as_non_owner_fails(owner, alice):
     """Test that non-owners cannot mint"""
-    token = VyperContract("track1-basic/src/MyToken.vy")
+    token = MyToken.deploy()
     
     # Alice tries to mint (should fail)
-    with boa.reverts("ownable: caller is not the owner"):
+    with boa.reverts("erc20: access is denied"):
         token.mint(alice, 1000 * 10**18, sender=alice)
 
 
 def test_burn(owner, alice):
     """Test burning tokens"""
-    token = VyperContract("track1-basic/src/MyToken.vy")
+    token = MyToken.deploy()
     
     # Transfer some tokens to alice first
     transfer_amount = 1000 * 10**18
@@ -120,7 +120,7 @@ def test_burn(owner, alice):
 
 def test_cannot_burn_more_than_balance(alice):
     """Test that users cannot burn more than they have"""
-    token = VyperContract("track1-basic/src/MyToken.vy")
+    token = MyToken.deploy()
     
     # Alice has no tokens, tries to burn
     with boa.reverts():


### PR DESCRIPTION
## Summary
- Fixed module initialization order in MyToken.vy (ownable must be initialized before erc20)
- Removed custom mint/burn functions that conflicted with ERC20 exports
- Updated deployment script to use correct Moccasin import syntax
- Fixed all tests to use proper contract deployment method
- Updated README with correct paths and commands

## Changes Made

### MyToken.vy
- Changed initialization order: `ownable` before `erc20[ownable := ownable]`
- Removed custom `mint()` and `burn()` functions as they're already exported from ERC20

### deploy_token.py
- Changed from `VyperContract("path")` to `from src import MyToken` and `MyToken.deploy()`
- Fixed relative paths

### test_token.py
- Updated all tests to use `MyToken.deploy()` instead of `VyperContract`
- Fixed expected error message in mint permission test

### README.md
- Updated installation path
- Added private key to deployment command
- Fixed test command path

## Test Results
All 7 tests now pass successfully:
```
tests/test_token.py ....... [100%]
============================== 7 passed in 0.19s ==============================
```

🤖 Generated with [Claude Code](https://claude.ai/code)